### PR TITLE
[NIAID-231] - Entities search 'or' statement fix

### DIFF
--- a/phenotips/entities-search/api/src/main/java/org/phenotips/data/api/internal/DocumentQuery.java
+++ b/phenotips/entities-search/api/src/main/java/org/phenotips/data/api/internal/DocumentQuery.java
@@ -146,14 +146,7 @@ public class DocumentQuery
 
         this.addObjectBinding(spaceAndClass);
 
-        Set<PropertyName> propertySet = this.propertyNameMap.get(spaceAndClass);
-
-        if (propertySet == null) {
-            propertySet = new HashSet<>();
-            this.propertyNameMap.put(spaceAndClass, propertySet);
-        }
-
-        propertySet.add(propertyName);
+        this.propertyNameMap.computeIfAbsent(spaceAndClass, k -> new HashSet<>()).add(propertyName);
     }
 
     /**
@@ -193,7 +186,7 @@ public class DocumentQuery
 
         this.objNameMap.put(this.mainSpaceClass, this.docName + "_obj");
 
-        this.expression = new QueryExpression(this).init(input);
+        this.expression = new QueryExpression(this, null).init(input);
 
         if (this.expression.isValid() && this.expression.validatesQuery()) {
             this.expression.createBindings();

--- a/phenotips/entities-search/api/src/main/java/org/phenotips/data/api/internal/SpaceAndClass.java
+++ b/phenotips/entities-search/api/src/main/java/org/phenotips/data/api/internal/SpaceAndClass.java
@@ -25,6 +25,9 @@ public class SpaceAndClass
     /** Class property key. */
     public static final String CLASS_KEY = EntitySearch.Keys.CLASS_KEY;
 
+    /** The space and class separator. */
+    public static final String SEPARATOR = ".";
+
     private final String spaceAndClassName;
 
     private final String spaceName;
@@ -115,7 +118,7 @@ public class SpaceAndClass
     @Override
     public boolean equals(Object o)
     {
-        if (o == null || !(o instanceof SpaceAndClass)) {
+        if (!(o instanceof SpaceAndClass)) {
             return false;
         } else {
             return this.spaceAndClassName.equals(((SpaceAndClass) o).spaceAndClassName);
@@ -133,7 +136,7 @@ public class SpaceAndClass
             throw new IllegalArgumentException("class provided is null/empty");
         }
 
-        String [] tokens = StringUtils.split(classAndSpace, ".");
+        String [] tokens = StringUtils.split(classAndSpace, SEPARATOR);
 
         if (tokens.length == 2) {
             return tokens;

--- a/phenotips/entities-search/api/src/main/java/org/phenotips/data/api/internal/builder/DocumentSearchBuilder.java
+++ b/phenotips/entities-search/api/src/main/java/org/phenotips/data/api/internal/builder/DocumentSearchBuilder.java
@@ -317,7 +317,6 @@ public class DocumentSearchBuilder implements Builder<JSONObject>
     private static DocumentSearchBuilder addAccessRight(String accessRight, DocumentSearchBuilder builder)
     {
         return builder
-            .newExpression()
             .newStringFilter("access")
             .setMatch(StringFilter.MATCH_EXACT)
             .setSpaceAndClass(PHENO_TIPS_COLLABORATOR_CLASS)


### PR DESCRIPTION
Updated entities search api now attempts to bind only one object during select, in order for or statements to perform the 'or' on the same object.